### PR TITLE
Test include directory fixed path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ if(FFMC_BUILD_TESTING)
     )
 
     target_include_directories(FFMCTest PRIVATE
-        FfFrameReader/test
+        "${FfFrameReader_SOURCE_DIR}/test"
     )
 
     target_link_libraries(FFMCTest


### PR DESCRIPTION
Point the include directory for the testing to the absolute location, instead of relying on running it from the project root.